### PR TITLE
Fix item id from 'Id' to 'id'

### DIFF
--- a/src/Models/GetOrderItemResponse.php
+++ b/src/Models/GetOrderItemResponse.php
@@ -17,7 +17,7 @@ class GetOrderItemResponse implements JsonSerializable
     /**
      * Id
      * @required
-     * @maps Id
+     * @maps id
      * @var string $id public property
      */
     public $id;
@@ -94,7 +94,7 @@ class GetOrderItemResponse implements JsonSerializable
     public function jsonSerialize()
     {
         $json = array();
-        $json['Id']                = $this->id;
+        $json['id']                = $this->id;
         $json['amount']            = $this->amount;
         $json['description']       = $this->description;
         $json['quantity']          = $this->quantity;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Fix item id from 'Id' to 'id'
| **Why?**          | Show item id in order's creation response
| **How?**          | Fix field name o GetOrderItemResponse

From
![image](https://user-images.githubusercontent.com/6605776/78195463-051cbb80-7456-11ea-98e7-1ecb939ef232.png)

To
![image](https://user-images.githubusercontent.com/6605776/78195315-b53df480-7455-11ea-9378-fbfa8fd43dd4.png)
