### PR TITLE
Feat/ Criando atributo service_referer_name

### DIFF
--- a/src/Models/CreateAddressRequest.php
+++ b/src/Models/CreateAddressRequest.php
@@ -95,6 +95,8 @@ class CreateAddressRequest implements JsonSerializable
      */
     public $line2;
 
+    public $service_referer_name;
+
     /**
      * Constructor to set initial or default values of member properties
      * @param string $street       Initialization value for $this->street
@@ -108,21 +110,24 @@ class CreateAddressRequest implements JsonSerializable
      * @param array  $metadata     Initialization value for $this->metadata
      * @param string $line1        Initialization value for $this->line1
      * @param string $line2        Initialization value for $this->line2
+     * @param string $service_referer_name        Initialization value for $this->service_referer_name
+     *
      */
     public function __construct()
     {
-        if (11 == func_num_args()) {
-            $this->street       = func_get_arg(0);
-            $this->number       = func_get_arg(1);
-            $this->zipCode      = func_get_arg(2);
-            $this->neighborhood = func_get_arg(3);
-            $this->city         = func_get_arg(4);
-            $this->state        = func_get_arg(5);
-            $this->country      = func_get_arg(6);
-            $this->complement   = func_get_arg(7);
-            $this->metadata     = func_get_arg(8);
-            $this->line1        = func_get_arg(9);
-            $this->line2        = func_get_arg(10);
+        if (12 == func_num_args()) {
+            $this->street               = func_get_arg(0);
+            $this->number               = func_get_arg(1);
+            $this->zipCode              = func_get_arg(2);
+            $this->neighborhood         = func_get_arg(3);
+            $this->city                 = func_get_arg(4);
+            $this->state                = func_get_arg(5);
+            $this->country              = func_get_arg(6);
+            $this->complement           = func_get_arg(7);
+            $this->metadata             = func_get_arg(8);
+            $this->line1                = func_get_arg(9);
+            $this->line2                = func_get_arg(10);
+            $this->service_referer_name = func_get_arg(11);
         }
     }
 
@@ -133,17 +138,18 @@ class CreateAddressRequest implements JsonSerializable
     public function jsonSerialize()
     {
         $json = array();
-        $json['street']       = $this->street;
-        $json['number']       = $this->number;
-        $json['zip_code']     = $this->zipCode;
-        $json['neighborhood'] = $this->neighborhood;
-        $json['city']         = $this->city;
-        $json['state']        = $this->state;
-        $json['country']      = $this->country;
-        $json['complement']   = $this->complement;
-        $json['metadata']     = $this->metadata;
-        $json['line_1']       = $this->line1;
-        $json['line_2']       = $this->line2;
+        $json['street']                   = $this->street;
+        $json['number']                   = $this->number;
+        $json['zip_code']                 = $this->zipCode;
+        $json['neighborhood']             = $this->neighborhood;
+        $json['city']                     = $this->city;
+        $json['state']                    = $this->state;
+        $json['country']                  = $this->country;
+        $json['complement']               = $this->complement;
+        $json['metadata']                 = $this->metadata;
+        $json['line_1']                   = $this->line1;
+        $json['line_2']                   = $this->line2;
+        $json['service_referer_name']     = $this->service_referer_name;
 
         return $json;
     }

--- a/src/Models/CreateOrderRequest.php
+++ b/src/Models/CreateOrderRequest.php
@@ -120,44 +120,49 @@ class CreateOrderRequest implements JsonSerializable
      */
     public $submerchant;
 
+    public $service_referer_name;
+
     /**
      * Constructor to set initial or default values of member properties
-     * @param array                  $items            Initialization value for $this->items
-     * @param Customer8              $customer         Initialization value for $this->customer
-     * @param array                  $payments         Initialization value for $this->payments
-     * @param string                 $code             Initialization value for $this->code
-     * @param string                 $customerId       Initialization value for $this->customerId
-     * @param Shipping3              $shipping         Initialization value for $this->shipping
-     * @param array                  $metadata         Initialization value for $this->metadata
-     * @param bool                   $antifraudEnabled Initialization value for $this->antifraudEnabled
-     * @param string                 $ip               Initialization value for $this->ip
-     * @param string                 $sessionId        Initialization value for $this->sessionId
-     * @param Location               $location         Initialization value for $this->location
-     * @param Device1                $device           Initialization value for $this->device
-     * @param bool                   $closed           Initialization value for $this->closed
-     * @param string                 $currency         Initialization value for $this->currency
-     * @param CreateAntifraudRequest $antifraud        Initialization value for $this->antifraud
-     * @param Submerchant            $submerchant      Initialization value for $this->submerchant
+     * @param array                  $items                    Initialization value for $this->items
+     * @param Customer8              $customer                 Initialization value for $this->customer
+     * @param array                  $payments                 Initialization value for $this->payments
+     * @param string                 $code                     Initialization value for $this->code
+     * @param string                 $customerId               Initialization value for $this->customerId
+     * @param Shipping3              $shipping                 Initialization value for $this->shipping
+     * @param array                  $metadata                 Initialization value for $this->metadata
+     * @param bool                   $antifraudEnabled         Initialization value for $this->antifraudEnabled
+     * @param string                 $ip                       Initialization value for $this->ip
+     * @param string                 $sessionId                Initialization value for $this->sessionId
+     * @param Location               $location                 Initialization value for $this->location
+     * @param Device1                $device                   Initialization value for $this->device
+     * @param bool                   $closed                   Initialization value for $this->closed
+     * @param string                 $currency                 Initialization value for $this->currency
+     * @param CreateAntifraudRequest $antifraud                Initialization value for $this->antifraud
+     * @param Submerchant            $submerchant              Initialization value for $this->submerchant
+     * @param string                 $service_referer_name     Initialization value for $this->service_referer_name
      */
     public function __construct()
     {
-        if (16 == func_num_args()) {
-            $this->items            = func_get_arg(0);
-            $this->customer         = func_get_arg(1);
-            $this->payments         = func_get_arg(2);
-            $this->code             = func_get_arg(3);
-            $this->customerId       = func_get_arg(4);
-            $this->shipping         = func_get_arg(5);
-            $this->metadata         = func_get_arg(6);
-            $this->antifraudEnabled = func_get_arg(7);
-            $this->ip               = func_get_arg(8);
-            $this->sessionId        = func_get_arg(9);
-            $this->location         = func_get_arg(10);
-            $this->device           = func_get_arg(11);
-            $this->closed           = func_get_arg(12);
-            $this->currency         = func_get_arg(13);
-            $this->antifraud        = func_get_arg(14);
-            $this->submerchant      = func_get_arg(15);
+        if (17 == func_num_args()) {
+            $this->items                     = func_get_arg(0);
+            $this->customer                  = func_get_arg(1);
+            $this->payments                  = func_get_arg(2);
+            $this->code                      = func_get_arg(3);
+            $this->customerId                = func_get_arg(4);
+            $this->shipping                  = func_get_arg(5);
+            $this->metadata                  = func_get_arg(6);
+            $this->antifraudEnabled          = func_get_arg(7);
+            $this->ip                        = func_get_arg(8);
+            $this->sessionId                 = func_get_arg(9);
+            $this->location                  = func_get_arg(10);
+            $this->device                    = func_get_arg(11);
+            $this->closed                    = func_get_arg(12);
+            $this->currency                  = func_get_arg(13);
+            $this->antifraud                 = func_get_arg(14);
+            $this->submerchant               = func_get_arg(15);
+            $this->service_referer_name      = func_get_arg(16);
+
         }
     }
 
@@ -168,22 +173,23 @@ class CreateOrderRequest implements JsonSerializable
     public function jsonSerialize()
     {
         $json = array();
-        $json['items']             = $this->items;
-        $json['customer']          = $this->customer;
-        $json['payments']          = $this->payments;
-        $json['code']              = $this->code;
-        $json['customer_id']       = $this->customerId;
-        $json['shipping']          = $this->shipping;
-        $json['metadata']          = $this->metadata;
-        $json['antifraud_enabled'] = $this->antifraudEnabled;
-        $json['ip']                = $this->ip;
-        $json['session_id']        = $this->sessionId;
-        $json['location']          = $this->location;
-        $json['device']            = $this->device;
-        $json['closed']            = $this->closed;
-        $json['currency']          = $this->currency;
-        $json['antifraud']         = $this->antifraud;
-        $json['submerchant']       = $this->submerchant;
+        $json['items']                      = $this->items;
+        $json['customer']                   = $this->customer;
+        $json['payments']                   = $this->payments;
+        $json['code']                       = $this->code;
+        $json['customer_id']                = $this->customerId;
+        $json['shipping']                   = $this->shipping;
+        $json['metadata']                   = $this->metadata;
+        $json['antifraud_enabled']          = $this->antifraudEnabled;
+        $json['ip']                         = $this->ip;
+        $json['session_id']                 = $this->sessionId;
+        $json['location']                   = $this->location;
+        $json['device']                     = $this->device;
+        $json['closed']                     = $this->closed;
+        $json['currency']                   = $this->currency;
+        $json['antifraud']                  = $this->antifraud;
+        $json['submerchant']                = $this->submerchant;
+        $json['service_referer_name']       = $this->service_referer_name;
 
         return $json;
     }


### PR DESCRIPTION
Criando atributo service_referer_name nas classes de criação de Pedido e de endereço.
Pagar.me que atualmente é a nova mundippag solicita que utilize o atributo  service_referer_name no lugar do metadata nas requests, sendo assim estou adicionando esse parâmetro para ser utilizado.